### PR TITLE
Fix: Configure vitest to run non-interactively by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest",
+  "test": "vitest run --reporter verbose",
     "test:ci": "vitest run --run",
     "test:watch": "vitest --watch",
     "coverage": "vitest run --coverage"


### PR DESCRIPTION
Updates the npm test script to use 'vitest run --reporter verbose' instead of the default interactive mode. This ensures tests run once and exit, making it more suitable for CI/CD pipelines and developer workflows that expect non-interactive test execution.